### PR TITLE
feat: Download exam slip API

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -3,8 +3,8 @@ testdata_dir = "testdata"
 tmp_dir = "tmp"
 
 [build]
-  args_bin = []
-  bin = "./tmp/main -d"
+  args_bin = ["-d"]
+  bin = "./tmp/main"
   cmd = "make build"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 
 # Copy source code and build
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o /app/gomaluum
+RUN CGO_ENABLED=0 GOOS=linux go build --ldflags="-checklinkname=0" -o /app/gomaluum
 
 # Certificate stage
 FROM alpine:latest AS certs

--- a/internal/constants/constant.go
+++ b/internal/constants/constant.go
@@ -1,15 +1,17 @@
 package constants
 
 const (
-	IiumPage             = "https://www.iium.edu.my/"
-	ImaluumPage          = "https://imaluum.iium.edu.my/"
-	ImaluumLogoutPage    = "https://imaluum.iium.edu.my/logout"
-	ImaluumCasPage       = "https://cas.iium.edu.my:8448/cas/login?service=https%3a%2f%2fimaluum.iium.edu.my%2fhome"
-	ImaluumCasLogoutPage = "https://cas.iium.edu.my:8448/cas/logout?service=http://imaluum.iium.edu.my/"
-	ImaluumProfilePage   = "https://imaluum.iium.edu.my/Profile"
-	ImaluumLoginPage     = "https://cas.iium.edu.my:8448/cas/login?service=https%3a%2f%2fimaluum.iium.edu.my%2fhome?service=https%3a%2f%2fimaluum.iium.edu.my%2fhome"
-	ImaluumHomePage      = "https://imaluum.iium.edu.my/home"
-	ImaluumSchedulePage  = "https://imaluum.iium.edu.my/MyAcademic/schedule"
-	ImaluumResultPage    = "https://imaluum.iium.edu.my/MyAcademic/result"
-	TimeSeparator        = "-"
+	IiumPage                    = "https://www.iium.edu.my/"
+	ImaluumPage                 = "https://imaluum.iium.edu.my/"
+	ImaluumLogoutPage           = "https://imaluum.iium.edu.my/logout"
+	ImaluumCasPage              = "https://cas.iium.edu.my:8448/cas/login?service=https%3a%2f%2fimaluum.iium.edu.my%2fhome"
+	ImaluumCasLogoutPage        = "https://cas.iium.edu.my:8448/cas/logout?service=http://imaluum.iium.edu.my/"
+	ImaluumProfilePage          = "https://imaluum.iium.edu.my/Profile"
+	ImaluumLoginPage            = "https://cas.iium.edu.my:8448/cas/login?service=https%3a%2f%2fimaluum.iium.edu.my%2fhome?service=https%3a%2f%2fimaluum.iium.edu.my%2fhome"
+	ImaluumHomePage             = "https://imaluum.iium.edu.my/home"
+	ImaluumSchedulePage         = "https://imaluum.iium.edu.my/MyAcademic/schedule"
+	ImaluumResultPage           = "https://imaluum.iium.edu.my/MyAcademic/result"
+	ImaluumConfirmationSlipPage = "https://imaluum.iium.edu.my/MyAcademic/confirmation-sem"
+	ImaluumExamSlipPage         = "https://imaluum.iium.edu.my/examslip"
+	TimeSeparator               = "-"
 )

--- a/internal/errors/downloads.error.go
+++ b/internal/errors/downloads.error.go
@@ -1,0 +1,6 @@
+package errors
+
+var ErrDownloadFailed = &CustomError{
+	Message:    "Failed to download the file",
+	StatusCode: 500,
+}

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -41,6 +41,7 @@ func (s *Server) LoginHandler(w http.ResponseWriter, r *http.Request) {
 	// Call the Login method from the GRPC server
 	resp, err := s.grpc.Login(ctx, user)
 	if err != nil {
+		logger.Sugar().Errorf("Login failed: %v", err)
 		errors.Render(w, r, err)
 		return
 	}

--- a/internal/server/auth.service.go
+++ b/internal/server/auth.service.go
@@ -125,5 +125,6 @@ func (s *GRPCServer) Login(_ context.Context, req *auth_proto.LoginRequest) (*au
 		}
 	}
 
+	log.Printf("Cookie MOD_AUTH_CAS not found in response: %v", cookies)
 	return nil, errors.ErrLoginFailed
 }

--- a/internal/server/downloads.go
+++ b/internal/server/downloads.go
@@ -1,0 +1,62 @@
+package server
+
+import (
+	"io"
+	"log"
+	"net/http"
+
+	"github.com/nrmnqdds/gomaluum/internal/constants"
+	"github.com/nrmnqdds/gomaluum/internal/errors"
+)
+
+// @Title ExamSlipHandler
+// @Description Get exam slip PDF from i-Ma'luum
+// @Tags scraper
+// @Produce application/pdf
+// @Param Authorization header string true "Insert your access token" default(Bearer <Add access token here>)
+// @Success 200 {string} string "Exam slip PDF"
+// @Router /api/download/exam-slip [get]
+func (s *Server) ExamSlipHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-type", "application/pdf")
+
+	var (
+		logger = s.log.GetLogger()
+		cookie = r.Context().Value(ctxToken).(string)
+		client = s.httpClient
+	)
+
+	req, err := http.NewRequest("GET", constants.ImaluumExamSlipPage, nil)
+	if err != nil {
+		log.Printf("Failed to create first request: %v", err)
+		if err := req.Body.Close(); err != nil {
+			log.Printf("Failed to close request body: %v", err)
+			errors.Render(w, r, errors.ErrFailedToCloseRequestBody)
+		}
+		errors.Render(w, r, errors.ErrURLParseFailed)
+	}
+
+	req.Header.Set("Connection", "Keep-Alive")
+	req.Header.Set("Accept-Language", "en-US")
+	req.Header.Set("User-Agent", "Mozilla/5.0")
+	req.Header.Set("Cookie", "MOD_AUTH_CAS="+cookie)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		logger.Sugar().Errorf("Failed to do request: %v", err)
+		errors.Render(w, r, errors.ErrURLParseFailed)
+		return
+	}
+	defer resp.Body.Close() // Use defer to close the body after we're done with it
+
+	// Stream to response
+	if _, err := io.Copy(w, resp.Body); err != nil {
+		logger.Sugar().Errorf("Failed to copy response body: %v", err)
+		errors.Render(w, r, errors.ErrDownloadFailed)
+		return
+	}
+
+	// if err := sonic.ConfigFastest.NewEncoder(w).Encode(resp); err != nil {
+	// 	logger.Sugar().Errorf("Failed to encode response: %v", err)
+	// 	errors.Render(w, r, errors.ErrDownloadFailed)
+	// }
+}

--- a/internal/server/downloads.go
+++ b/internal/server/downloads.go
@@ -54,9 +54,4 @@ func (s *Server) ExamSlipHandler(w http.ResponseWriter, r *http.Request) {
 		errors.Render(w, r, errors.ErrDownloadFailed)
 		return
 	}
-
-	// if err := sonic.ConfigFastest.NewEncoder(w).Encode(resp); err != nil {
-	// 	logger.Sugar().Errorf("Failed to encode response: %v", err)
-	// 	errors.Render(w, r, errors.ErrDownloadFailed)
-	// }
 }

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -66,7 +66,7 @@ func (s *Server) RegisterRoutes() http.Handler {
 			r.Get("/logout", s.LogoutHandler)
 
 			r.Route("/download", func(r chi.Router) {
-				r.Get("/exam-slip", s.ConfirmationSlipHandler)
+				r.Get("/exam-slip", s.ExamSlipHandler)
 			})
 		})
 	})

--- a/internal/server/routes.go
+++ b/internal/server/routes.go
@@ -64,6 +64,10 @@ func (s *Server) RegisterRoutes() http.Handler {
 			r.Get("/schedule", s.ScheduleHandler)
 			r.Get("/result", s.ResultHandler)
 			r.Get("/logout", s.LogoutHandler)
+
+			r.Route("/download", func(r chi.Router) {
+				r.Get("/exam-slip", s.ConfirmationSlipHandler)
+			})
 		})
 	})
 


### PR DESCRIPTION
This pull request introduces a new API endpoint for downloading exam slip PDFs, refines error handling, and makes several improvements to configuration and logging. The main focus is on adding the exam slip download feature, updating constants, and improving reliability and observability.

### Exam Slip Download Feature

* Added the `ExamSlipHandler` to `internal/server/downloads.go`, allowing users to download their exam slip PDF from the i-Ma'luum system. The handler streams the PDF directly to the response and includes robust error handling and logging.
* Registered the new `/api/download/exam-slip` route under `/download` in `internal/server/routes.go`, making the exam slip download endpoint accessible via the API.

### Constants Update

* Added new constants `ImaluumConfirmationSlipPage` and `ImaluumExamSlipPage` to `internal/constants/constant.go` to support the new download functionality.

### Error Handling Improvements

* Introduced a new error type `ErrDownloadFailed` in `internal/errors/downloads.error.go` for handling download failures in a standardized way.

### Logging and Observability

* Enhanced logging in authentication flows: added error logging in `internal/server/auth.go` when login fails, and a debug log in `internal/server/auth.service.go` for missing authentication cookies. [[1]](diffhunk://#diff-d29f0c567fbfbadef2569812f9989ddac4a85c95b788eae82170cf1ea8995b06R44) [[2]](diffhunk://#diff-3f24564727e7661ffd3ee4e909b44e71fc1f7b3386ba016d07be01cc16479d72R128)

### Build and Configuration Updates

* Updated `.air.toml` to streamline build arguments and binary execution for local development.
* Modified the `Dockerfile` to add linker flags for Go builds, potentially improving binary compatibility.