### PR TITLE
fix: prevent race condition on regenerating token

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,4 @@
+version: "2"
 linters:
   enable:
     - revive

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/swaggo/swag v1.16.4
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.14.0
 	google.golang.org/grpc v1.69.2
 	google.golang.org/protobuf v1.36.0
 )

--- a/internal/server/auth.go
+++ b/internal/server/auth.go
@@ -46,8 +46,14 @@ func (s *Server) LoginHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	payload := TokenPayload{
+		username:      resp.Username,
+		password:      resp.Password,
+		imaluumCookie: resp.Token,
+	}
+
 	// Generate a new PASETO token
-	newCookie, _, err := s.GeneratePasetoToken(resp.Token, resp.Username, resp.Password)
+	newCookie, _, err := s.GeneratePasetoToken(payload)
 	if err != nil {
 		logger.Sugar().Errorf("Failed to generate PASETO token: %v", err)
 		errors.Render(w, r, errors.ErrFailedToDecodePASETO)

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -34,16 +34,16 @@ func (s *Server) PasetoAuthenticator() func(http.Handler) http.Handler {
 				return
 			}
 
-			if token == "" {
+			if token == nil {
 				logger.Sugar().Warn("Token is empty")
 				http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 				return
 			}
 
-			logger.Sugar().Debugf("Token is authenticated: %v", fmt.Sprintf("MOD_AUTH_CAS=%s", token))
+			logger.Sugar().Debugf("Token is authenticated: %v", fmt.Sprintf("MOD_AUTH_CAS=%s", token.imaluumCookie))
 
 			// Create a new context from the request context and add the token to it
-			ctx := context.WithValue(r.Context(), ctxToken, token)
+			ctx := context.WithValue(r.Context(), ctxToken, token.imaluumCookie)
 
 			// Token is authenticated, pass it through
 			next.ServeHTTP(w, r.WithContext(ctx))

--- a/internal/server/paseto.go
+++ b/internal/server/paseto.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"log"
 	"time"
 
 	"github.com/cristalhq/base64"
@@ -10,11 +11,17 @@ import (
 	pb "github.com/nrmnqdds/gomaluum/internal/proto"
 )
 
+type TokenPayload struct {
+	username      string
+	password      string
+	imaluumCookie string
+}
+
 // GeneratePasetoToken generates a PASETO token for the given original uia cookie
 // origin: the original uia cookie
 // username: the username of the user
 // password: the password of the user in base64
-func (s *Server) GeneratePasetoToken(origin, username, originPassword string) (string, string, error) {
+func (s *Server) GeneratePasetoToken(payload TokenPayload) (string, string, error) {
 	token := s.paseto.Token
 
 	token.SetIssuedAt(time.Now())
@@ -24,11 +31,15 @@ func (s *Server) GeneratePasetoToken(origin, username, originPassword string) (s
 	// token.SetExpiration(time.Now().Add(time.Minute * 1)) // 1 minutes
 	token.SetIssuer("gomaluum")
 
+	originPassword := payload.password
+	imaluumCookie := payload.imaluumCookie
+	username := payload.username
+
 	// encode the base64 password
 	password := []byte(originPassword)
 	base64Password := base64.StdEncoding.EncodeToString(password)
 
-	token.SetString("origin", origin)
+	token.SetString("imaluumCookie", imaluumCookie)
 	token.SetString("username", username)
 	token.SetString("password", base64Password)
 
@@ -36,11 +47,11 @@ func (s *Server) GeneratePasetoToken(origin, username, originPassword string) (s
 
 	s.paseto.Token = token
 
-	return signed, origin, nil
+	return signed, imaluumCookie, nil
 }
 
 // DecodePasetoToken decodes the given PASETO token and returns the original uia cookie
-func (s *Server) DecodePasetoToken(token string) (string, error) {
+func (s *Server) DecodePasetoToken(token string) (*TokenPayload, error) {
 	parser := paseto.NewParserWithoutExpiryCheck() // Don't use NewParser() which will checks expiry by default
 	logger := s.log.GetLogger()
 
@@ -54,13 +65,13 @@ func (s *Server) DecodePasetoToken(token string) (string, error) {
 	if err != nil {
 		logger.Sugar().Errorf("Failed to parse token: %v", err)
 
-		return "", err
+		return nil, err
 	}
 
 	tokenExpiryDate, err := decodedToken.GetExpiration()
 	if err != nil {
 		logger.Sugar().Errorf("Failed to get expiration: %v", err)
-		return "", err
+		return nil, err
 	}
 
 	today := time.Now()
@@ -76,29 +87,50 @@ func (s *Server) DecodePasetoToken(token string) (string, error) {
 		decodedPassword, err := base64.StdEncoding.DecodeString(password)
 		if err != nil {
 			logger.Sugar().Errorf("Failed to decode password: %v", err)
-			return "", err
+			return nil, err
 		}
-		// regenerate the token
-		logger.Sugar().Infof("Refreshing session token with username: %s, password: %s", username, string(decodedPassword))
 
-		resp, err := s.grpc.Login(ctx, &pb.LoginRequest{
-			Username: username,
-			Password: string(decodedPassword),
-		})
+		refresh := func() (string, time.Time, error) {
+			// regenerate the token
+			logger.Sugar().Infof("Refreshing session token with username: %s, password: %s", username, string(decodedPassword))
 
+			resp, err := s.grpc.Login(ctx, &pb.LoginRequest{
+				Username: username,
+				Password: string(decodedPassword),
+			})
+
+			if err != nil {
+				logger.Sugar().Errorf("Failed to login: %v", err)
+				return "", time.Now(), err
+			}
+
+			return resp.Token, time.Now(), nil
+		}
+
+		newToken, err := s.tokenManager.GetToken(username, refresh)
 		if err != nil {
-			logger.Sugar().Errorf("Failed to login: %v", err)
-			return "", err
+			logger.Sugar().Errorf("Failed to get token: %v", err)
+			log.Fatal(err)
 		}
 
-		logger.Sugar().Infof("Regenerated token: %s with origin for user: %s", resp.Token, username)
-		return resp.Token, nil
+		logger.Sugar().Infof("Refreshed token: %s with origin for user: %s", newToken, username)
+		return &TokenPayload{
+			username:      username,
+			password:      string(decodedPassword),
+			imaluumCookie: newToken,
+		}, nil
+
+		// End of if token expired
 	}
 
-	origin, err := decodedToken.GetString("origin")
-	if err != nil {
-		return "", err
-	}
+	// If token not expired yet
+	username, _ := decodedToken.GetString("username")
+	password, _ := decodedToken.GetString("password")
+	imaluumCookie, _ := decodedToken.GetString("imaluumCookie")
 
-	return origin, nil
+	return &TokenPayload{
+		username:      username,
+		password:      password,
+		imaluumCookie: imaluumCookie,
+	}, nil
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	auth_proto "github.com/nrmnqdds/gomaluum/internal/proto"
 	"github.com/nrmnqdds/gomaluum/pkg/logger"
 	"github.com/nrmnqdds/gomaluum/pkg/paseto"
+	"github.com/nrmnqdds/gomaluum/pkg/sf"
 )
 
 type Handlers interface {
@@ -40,11 +41,12 @@ func NewGRPCServer() *GRPCServer {
 }
 
 type Server struct {
-	log        *logger.AppLogger
-	paseto     *paseto.AppPaseto
-	grpc       *GRPCServer
-	httpClient *http.Client
-	port       int
+	log          *logger.AppLogger
+	paseto       *paseto.AppPaseto
+	grpc         *GRPCServer
+	httpClient   *http.Client
+	port         int
+	tokenManager *sf.TokenManager
 }
 
 func NewServer(port int, grpc *GRPCServer) *http.Server {
@@ -61,12 +63,15 @@ func NewServer(port int, grpc *GRPCServer) *http.Server {
 		return nil
 	}
 
+	tm := sf.NewTokenManager()
+
 	NewServer := &Server{
-		port:       port,
-		log:        logger.New(),
-		paseto:     paseto,
-		grpc:       grpc,
-		httpClient: httpClient,
+		port:         port,
+		log:          logger.New(),
+		paseto:       paseto,
+		grpc:         grpc,
+		httpClient:   httpClient,
+		tokenManager: tm,
 	}
 
 	// Declare Server config

--- a/pkg/sf/singleflight.go
+++ b/pkg/sf/singleflight.go
@@ -1,0 +1,72 @@
+package sf
+
+import (
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+type TokenEntry struct {
+	Token  string
+	Expiry time.Time
+}
+
+type TokenManager struct {
+	mu     sync.RWMutex
+	tokens map[string]*TokenEntry
+	sf     singleflight.Group
+}
+
+func NewTokenManager() *TokenManager {
+	return &TokenManager{
+		tokens: make(map[string]*TokenEntry),
+	}
+}
+
+func (tm *TokenManager) GetToken(
+	matric string,
+	refreshFunc func() (string, time.Time, error),
+) (string, error) {
+	// Step 1: check if we already have a valid token
+	tm.mu.RLock()
+	entry, ok := tm.tokens[matric]
+	if ok && time.Now().Before(entry.Expiry) {
+		defer tm.mu.RUnlock()
+		return entry.Token, nil
+	}
+	tm.mu.RUnlock()
+
+	// Step 2: collapse concurrent refresh for the SAME matric
+	v, err, _ := tm.sf.Do(matric, func() (any, error) {
+		// double-check after winning singleflight
+		tm.mu.RLock()
+		entry, ok := tm.tokens[matric]
+		if ok && time.Now().Before(entry.Expiry) {
+			defer tm.mu.RUnlock()
+			return entry.Token, nil
+		}
+		tm.mu.RUnlock()
+
+		// refresh
+		token, expiry, err := refreshFunc()
+		if err != nil {
+			return "", err
+		}
+
+		// update safely
+		tm.mu.Lock()
+		tm.tokens[matric] = &TokenEntry{
+			Token:  token,
+			Expiry: expiry,
+		}
+		tm.mu.Unlock()
+
+		return token, nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}


### PR DESCRIPTION
This pull request introduces a new `TokenManager` using singleflight to efficiently handle token refreshes, refactors the PASETO token handling to use a structured payload, and updates authentication flows to leverage these improvements. The changes enhance concurrency safety, reduce redundant token refreshes, and clarify token data handling.

**Token management and concurrency improvements:**

* Added a new `TokenManager` in `pkg/sf/singleflight.go` that uses `golang.org/x/sync/singleflight` to prevent concurrent token refreshes for the same user, ensuring only one refresh occurs at a time and safely caching tokens with their expiry. [[1]](diffhunk://#diff-5edd2ee109d57fc86ccb40de674026d57a811dd647eb97b7e71f8e3e7e946367R1-R72) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R25)
* Integrated `TokenManager` into the `Server` struct and initialization in `internal/server/server.go`, making it available for token operations. [[1]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R14) [[2]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R49) [[3]](diffhunk://#diff-d0706a4ae4ecf91c5224ca388f31a087a36af06c40dc81321da7958b25c70b23R66-R74)

**PASETO token handling refactor:**

* Refactored PASETO token generation and decoding to use a new `TokenPayload` struct, improving clarity and reducing error-prone parameter passing in `internal/server/paseto.go`. [[1]](diffhunk://#diff-795e22a074054a00d0e05a1473aa86a9b2e72dab566f7b51dbbabd857aa90477R14-R54) [[2]](diffhunk://#diff-d29f0c567fbfbadef2569812f9989ddac4a85c95b788eae82170cf1ea8995b06R49-R56) [[3]](diffhunk://#diff-795e22a074054a00d0e05a1473aa86a9b2e72dab566f7b51dbbabd857aa90477L56-R80) [[4]](diffhunk://#diff-795e22a074054a00d0e05a1473aa86a9b2e72dab566f7b51dbbabd857aa90477L75-R135)
* Token expiration is now checked, and if expired, a refresh is triggered via `TokenManager`, ensuring up-to-date tokens with minimal redundant refreshes. [[1]](diffhunk://#diff-795e22a074054a00d0e05a1473aa86a9b2e72dab566f7b51dbbabd857aa90477L56-R80) [[2]](diffhunk://#diff-795e22a074054a00d0e05a1473aa86a9b2e72dab566f7b51dbbabd857aa90477L75-R135)

**Middleware and logging updates:**

* Updated authentication middleware to work with the new `TokenPayload` structure and improved logging for token authentication and refresh events. [[1]](diffhunk://#diff-ac9f75acde77fba2851e878733ac49787bb8f744a064fd351751e8b248ec627bL37-R46) [[2]](diffhunk://#diff-795e22a074054a00d0e05a1473aa86a9b2e72dab566f7b51dbbabd857aa90477R5)

**Configuration:**

* Added a `.golangci.yaml` configuration file for linter settings.